### PR TITLE
Renames SDK global to GleanWebSDK to match new naming convention

### DIFF
--- a/src/theme/Chat/index.tsx
+++ b/src/theme/Chat/index.tsx
@@ -10,8 +10,8 @@ export default function ChatPage(): JSX.Element {
   const { options } = usePluginData('docusaurus-plugin-search-glean') as { options: PluginOptions };
 
   const initializeChat = (themeVariant: ThemeVariant = 'light') => {
-    if (window.EmbeddedSearch && containerRef.current) {
-      window.EmbeddedSearch.renderChat(containerRef.current, {
+    if (window.GleanWebSDK && containerRef.current) {
+      window.GleanWebSDK.renderChat(containerRef.current, {
         ...(options.chatOptions || {}),
         themeVariant,
       });

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -10,8 +10,8 @@ export default function SearchBarWrapper() {
   const { options } = useGleanConfig();
 
   const initializeSearch = (themeVariant: ThemeVariant = 'light') => {
-    if (window.EmbeddedSearch && containerRef.current) {
-      window.EmbeddedSearch.attach(containerRef.current, {
+    if (window.GleanWebSDK && containerRef.current) {
+      window.GleanWebSDK.attach(containerRef.current, {
         ...(options.searchOptions as Required<ModalSearchOptions>),
         themeVariant,
       });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ import { ModalSearchOptions, ChatOptions } from '@gleanwork/web-sdk';
 
 declare global {
   interface Window {
-    EmbeddedSearch: {
+    GleanWebSDK: {
       attach: (element: HTMLElement, options: ModalSearchOptions) => void;
       renderChat: (element: HTMLElement, options: ChatOptions) => void;
     };


### PR DESCRIPTION
This pull request includes changes to update the integration with the Glean Web SDK by replacing references to `EmbeddedSearch` with `GleanWebSDK`. The most important changes involve updating the initialization functions for chat and search components and modifying the global `Window` interface.

Integration updates:

* [`src/theme/Chat/index.tsx`](diffhunk://#diff-ce0f100bbd429537ac36585b898ecb8808144aff18eeb8e5939aceb38867dc39L13-R14): Updated `initializeChat` function to use `GleanWebSDK.renderChat` instead of `EmbeddedSearch.renderChat`.
* [`src/theme/SearchBar/index.tsx`](diffhunk://#diff-6f03e8dca6a63296ef50ea60f54430dd5992c132c8f470074b4f5ada92ea50a6L13-R14): Updated `initializeSearch` function to use `GleanWebSDK.attach` instead of `EmbeddedSearch.attach`.

Type definition update:

* [`src/types/index.ts`](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476L5-R5): Modified the global `Window` interface to replace `EmbeddedSearch` with `GleanWebSDK`.