### PR TITLE
Updates to use node package variant of GleanWebSDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: ['18', '20']
+        node: ['18', '20', '22']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ module.exports = {
 
 | Property        | Type                                   | Description                                                |
 | --------------- | -------------------------------------- | ---------------------------------------------------------- |
-| `sdkUrl`        | `string`                               | URL to the SDK required for the plugin.                    |
 | `searchOptions` | `Partial<ModalSearchOptions> \| false` | Options for search functionality. Pass `false` to disable. |
 | `chatOptions`   | `Partial<ChatOptions> \| false`        | Options for chat functionality. Pass `false` to disable.   |
 | `chatPagePath`  | `string`                               | Path to the chat page within the application.              |

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "watch": "run-p -c copy:watch build:watch"
   },
   "dependencies": {
-    "@gleanwork/web-sdk": "^2.0.0",
+    "@gleanwork/web-sdk": "^2.1.0-rc.1",
     "lodash.mergewith": "^4.6.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "watch": "run-p -c copy:watch build:watch"
   },
   "dependencies": {
-    "@gleanwork/web-sdk": "^2.1.0-rc.1",
+    "@gleanwork/web-sdk": "^2.1.0",
     "lodash.mergewith": "^4.6.2"
   },
   "devDependencies": {
@@ -85,7 +85,7 @@
     "node": ">=18"
   },
   "volta": {
-    "node": "18.19.1",
+    "node": "22.11.0",
     "yarn": "3.8.1"
   },
   "publishConfig": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,20 +33,6 @@ export default function searchGlean(context: LoadContext, options: Options): Plu
         });
       }
     },
-
-    injectHtmlTags() {
-      return {
-        headTags: [
-          {
-            tagName: 'script',
-            attributes: {
-              async: true,
-              src: options.sdkUrl,
-            },
-          },
-        ],
-      };
-    },
   };
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -4,7 +4,6 @@ import { ChatOptions, ModalSearchOptions } from '@gleanwork/web-sdk';
 import mergeWith from 'lodash/mergeWith';
 
 export type PluginOptions = {
-  sdkUrl: string;
   searchOptions: Partial<ModalSearchOptions> | false;
   chatOptions: Partial<ChatOptions> | false;
   chatPagePath: string;
@@ -13,7 +12,6 @@ export type PluginOptions = {
 export type Options = Partial<PluginOptions>;
 
 export const DEFAULT_PLUGIN_OPTIONS: PluginOptions = {
-  sdkUrl: 'https://app.glean.com/embedded-search-latest.min.js',
   searchOptions: {},
   chatOptions: {},
   chatPagePath: 'chat',
@@ -77,7 +75,7 @@ const ModalSearchOptionsSchema = commonOptionsSchema.keys({
 });
 
 const ChatOptionsSchema = commonOptionsSchema.keys({
-  agent: Joi.string().optional(),
+  agent: Joi.string().valid('DEFAULT', 'GPT').optional(),
   applicationId: Joi.string().optional(),
   chatId: Joi.string().optional(),
   customizations: ChatCustomizationsSchema.optional(),
@@ -88,7 +86,6 @@ const ChatOptionsSchema = commonOptionsSchema.keys({
 });
 
 const PluginOptionsSchema = Joi.object({
-  sdkUrl: Joi.string().uri().default(DEFAULT_PLUGIN_OPTIONS.sdkUrl),
   searchOptions: Joi.alternatives()
     .try(ModalSearchOptionsSchema, Joi.boolean().valid(false))
     .default(DEFAULT_PLUGIN_OPTIONS.searchOptions),

--- a/tests/options-test.ts
+++ b/tests/options-test.ts
@@ -24,66 +24,50 @@ describe('PluginOptions validation', () => {
     );
   });
 
-  test('validates sdkUrl format', () => {
-    const options = { sdkUrl: 'not-a-valid-url' };
-    expect(() => testValidateOptions(options)).toThrowErrorMatchingInlineSnapshot(
-      `[ValidationError: "sdkUrl" must be a valid uri]`,
-    );
-  });
-
   test('validates partial searchOptions without throwing', () => {
     const options = {
-      sdkUrl: 'https://app.glean.com/embedded-search-latest.min.js',
       searchOptions: { key: 'test' },
     };
     expect(testValidateOptions(options)).toMatchObject({
-      sdkUrl: expect.any(String),
       searchOptions: expect.any(Object),
     });
   });
 
   test('validates searchOptions can be false without throwing', () => {
     const options = {
-      sdkUrl: 'https://app.glean.com/embedded-search-latest.min.js',
       searchOptions: false as const,
     };
     expect(testValidateOptions(options)).toMatchObject({
-      sdkUrl: expect.any(String),
       searchOptions: false,
     });
   });
 
   test('validates partial chatOptions without throwing', () => {
     const options = {
-      sdkUrl: 'https://app.glean.com/embedded-search-latest.min.js',
-      chatOptions: { agent: 'agent_id' },
+      chatOptions: { agent: 'DEFAULT' as const },
     };
     expect(testValidateOptions(options)).toMatchObject({
-      sdkUrl: expect.any(String),
       chatOptions: expect.any(Object),
     });
   });
 
   test('validates chatOptions can be false without throwing', () => {
     const options = {
-      sdkUrl: 'https://app.glean.com/embedded-search-latest.min.js',
       chatOptions: false as const,
     };
     expect(testValidateOptions(options)).toMatchObject({
-      sdkUrl: expect.any(String),
       chatOptions: false,
     });
   });
 
   test('allows all valid options without throwing', () => {
     const options = {
-      sdkUrl: 'https://app.glean.com/embedded-search-latest.min.js',
       searchOptions: {
         key: 'testKey',
         onSearch: () => console.log('Search initiated'),
       },
       chatOptions: {
-        agent: 'agent_id',
+        agent: 'DEFAULT' as const,
         onChat: (chatId?: string) => console.log(`Chat initiated with ID: ${chatId}`),
       },
     };
@@ -98,14 +82,13 @@ describe('PluginOptions normalization', () => {
   });
 
   test('normalizePluginOptions - partial options provided', () => {
-    const options = { sdkUrl: 'https://app.glean.com/embedded-search-v2.min.js' };
+    const options = {};
     const result = normalizePluginOptions(options);
     expect(result).toEqual({ ...DEFAULT_PLUGIN_OPTIONS, ...options });
   });
 
   test('normalizePluginOptions - all options provided', () => {
     const options = {
-      sdkUrl: 'https://app.glean.com/embedded-search-v2.min.js',
       searchOptions: {
         filters: [
           { key: 'app', value: 'github' },
@@ -122,7 +105,6 @@ describe('PluginOptions normalization', () => {
   test('normalizePluginOptions - extra options provided', () => {
     const options = {
       ...DEFAULT_PLUGIN_OPTIONS,
-      sdkUrl: 'https://app.glean.com/embedded-search-v2.min.js',
       extraOption: 'extraValue',
     };
     const result = normalizePluginOptions(options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2286,10 +2286,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gleanwork/web-sdk@npm:^2.1.0-rc.1":
-  version: 2.1.0-rc.2
-  resolution: "@gleanwork/web-sdk@npm:2.1.0-rc.2"
-  checksum: 14fdfc142be2ee4ac3d786cf5fc6b4afa1147c6da0a9c31f41d517ad92df5f0fa19a63ea2598747d33e6dbb76a3647cb2f92ab82eecd336d451a7941235e9dca
+"@gleanwork/web-sdk@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@gleanwork/web-sdk@npm:2.1.0"
+  checksum: f8bb432191c58c2d930a4d9bc1208e26b76b8ceaa6945076ab52713049d2aadc1bb63cce3de72fb6e438e2f79fba68e9d0515b72d38331ba3ffbc9d9c0032c07
   languageName: node
   linkType: hard
 
@@ -6103,7 +6103,7 @@ __metadata:
     "@docusaurus/types": ^3.0.0
     "@docusaurus/utils": ^3.0.0
     "@docusaurus/utils-validation": ^3.0.0
-    "@gleanwork/web-sdk": ^2.1.0-rc.1
+    "@gleanwork/web-sdk": ^2.1.0
     "@release-it-plugins/lerna-changelog": ^5.0.0
     "@types/lodash": ^4.14.202
     "@types/node": ^20.11.30

--- a/yarn.lock
+++ b/yarn.lock
@@ -2286,10 +2286,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gleanwork/web-sdk@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@gleanwork/web-sdk@npm:2.0.0"
-  checksum: 8d63a48c710a65e69e47b830ec083addaa2bd790b3fc2a72ed78ec7170944288d94da46b4ff2d24e4c75d0583022a4bedfb9a5bc0230ed1dd4ad7de4eaf245b0
+"@gleanwork/web-sdk@npm:^2.1.0-rc.1":
+  version: 2.1.0-rc.2
+  resolution: "@gleanwork/web-sdk@npm:2.1.0-rc.2"
+  checksum: 14fdfc142be2ee4ac3d786cf5fc6b4afa1147c6da0a9c31f41d517ad92df5f0fa19a63ea2598747d33e6dbb76a3647cb2f92ab82eecd336d451a7941235e9dca
   languageName: node
   linkType: hard
 
@@ -6103,7 +6103,7 @@ __metadata:
     "@docusaurus/types": ^3.0.0
     "@docusaurus/utils": ^3.0.0
     "@docusaurus/utils-validation": ^3.0.0
-    "@gleanwork/web-sdk": ^2.0.0
+    "@gleanwork/web-sdk": ^2.1.0-rc.1
     "@release-it-plugins/lerna-changelog": ^5.0.0
     "@types/lodash": ^4.14.202
     "@types/node": ^20.11.30


### PR DESCRIPTION
This pull request includes several changes to the `docusaurus-plugin-search-glean` plugin to remove the `sdkUrl` property and update dependencies. The most important changes include removing the `sdkUrl` property from various files, updating the SDK version, and modifying validation and normalization tests.

### Removal of `sdkUrl` property:

* [`src/options.ts`](diffhunk://#diff-2123f97b7bf9480a61717c843425e483e8d97819592e8c04e4e149eb65b451e8L7): Removed `sdkUrl` from `PluginOptions` type and `DEFAULT_PLUGIN_OPTIONS` object. [[1]](diffhunk://#diff-2123f97b7bf9480a61717c843425e483e8d97819592e8c04e4e149eb65b451e8L7) [[2]](diffhunk://#diff-2123f97b7bf9480a61717c843425e483e8d97819592e8c04e4e149eb65b451e8L16)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L162): Removed `sdkUrl` from the property list.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L36-L49): Removed the `injectHtmlTags` method that used `sdkUrl`.
* [`tests/options-test.ts`](diffhunk://#diff-a5b670ff2d8541bfd6b7544009a0f7c6660a2f5e160cd858f533d4334900eef2L27-R70): Removed `sdkUrl` validation and normalization tests. [[1]](diffhunk://#diff-a5b670ff2d8541bfd6b7544009a0f7c6660a2f5e160cd858f533d4334900eef2L27-R70) [[2]](diffhunk://#diff-a5b670ff2d8541bfd6b7544009a0f7c6660a2f5e160cd858f533d4334900eef2L101-L108) [[3]](diffhunk://#diff-a5b670ff2d8541bfd6b7544009a0f7c6660a2f5e160cd858f533d4334900eef2L125)

### Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L46-R46): Updated `@gleanwork/web-sdk` dependency to version `^2.1.0-rc.1`.

### Validation schema updates:

* [`src/options.ts`](diffhunk://#diff-2123f97b7bf9480a61717c843425e483e8d97819592e8c04e4e149eb65b451e8L80-R78): Updated `ChatOptionsSchema` to validate `agent` property with specific values. [[1]](diffhunk://#diff-2123f97b7bf9480a61717c843425e483e8d97819592e8c04e4e149eb65b451e8L80-R78) [[2]](diffhunk://#diff-2123f97b7bf9480a61717c843425e483e8d97819592e8c04e4e149eb65b451e8L91)