### PR TITLE
Dynamically load `@gleanwork/web-sdk` to fix SSR

### DIFF
--- a/src/hooks/useThemeChange.ts
+++ b/src/hooks/useThemeChange.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ThemeVariant } from '@gleanwork/web-sdk';
+import type { ThemeVariant } from '@gleanwork/web-sdk';
 
 interface ThemeChangeCallback {
   (theme: ThemeVariant): void;

--- a/src/theme/Chat/index.tsx
+++ b/src/theme/Chat/index.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useRef } from 'react';
+import { type ReactNode, useEffect, useRef } from 'react';
 import { usePluginData } from '@docusaurus/useGlobalData';
-import GleanWebSDK, { ThemeVariant } from '@gleanwork/web-sdk';
+import GleanWebSDK, { type ThemeVariant } from '@gleanwork/web-sdk';
 
 import { PluginOptions } from '../../options';
 import useThemeChange from '../../hooks/useThemeChange';
 
-export default function ChatPage(): JSX.Element {
+export default function ChatPage(): ReactNode {
   const containerRef = useRef<HTMLDivElement>(null);
   const { options } = usePluginData('docusaurus-plugin-search-glean') as { options: PluginOptions };
 

--- a/src/theme/ChatPage/index.tsx
+++ b/src/theme/ChatPage/index.tsx
@@ -1,8 +1,9 @@
 import Layout from '@theme/Layout';
+import type { ReactNode } from 'react';
 
 import Chat from '../Chat';
 
-export default function ChatPage(): JSX.Element {
+export default function ChatPage(): ReactNode {
   return (
     <Layout>
       <Chat />

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -11,12 +11,16 @@ export default function SearchBarWrapper() {
 
   const initializeSearch = (themeVariant: ThemeVariant = 'light') => {
     if (containerRef.current) {
-      import('@gleanwork/web-sdk').then(({ attach }) => {
-        attach(containerRef.current!, {
-          ...(options.searchOptions as Required<ModalSearchOptions>),
-          themeVariant,
+      import('@gleanwork/web-sdk')
+        .then(({ attach }) => {
+          attach(containerRef.current!, {
+            ...(options.searchOptions as Required<ModalSearchOptions>),
+            themeVariant,
+          });
+        })
+        .catch((error) => {
+          console.error('Failed to load @gleanwork/web-sdk:', error);
         });
-      });
     }
   };
 

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import GleanWebSDK, { ModalSearchOptions, ThemeVariant } from '@gleanwork/web-sdk';
+import type { ModalSearchOptions, ThemeVariant } from '@gleanwork/web-sdk';
 
 import { SearchButton } from '../SearchButton';
 import { useGleanConfig } from '../../utils';
@@ -11,9 +11,11 @@ export default function SearchBarWrapper() {
 
   const initializeSearch = (themeVariant: ThemeVariant = 'light') => {
     if (containerRef.current) {
-      GleanWebSDK.attach(containerRef.current, {
-        ...(options.searchOptions as Required<ModalSearchOptions>),
-        themeVariant,
+      import('@gleanwork/web-sdk').then(({ attach }) => {
+        attach(containerRef.current!, {
+          ...(options.searchOptions as Required<ModalSearchOptions>),
+          themeVariant,
+        });
       });
     }
   };

--- a/src/types/glean.ts
+++ b/src/types/glean.ts
@@ -1,4 +1,4 @@
-import { ModalSearchOptions, ChatOptions } from '@gleanwork/web-sdk';
+import type { ModalSearchOptions, ChatOptions } from '@gleanwork/web-sdk';
 
 export type ThemeConfig = {
   glean: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { ModalSearchOptions, ChatOptions } from '@gleanwork/web-sdk';
+import type { ModalSearchOptions, ChatOptions } from '@gleanwork/web-sdk';
 
 declare global {
   interface Window {


### PR DESCRIPTION
I tried to use `docusaurus-plugin-search-glean` with Docusaurus 3.7.0 and had the following error during site build:

```
  | 2025-05-29 12:00:39 UTC | [INFO] Docusaurus version: 3.7.0
  | 2025-05-29 12:00:39 UTC | Node version: v20.10.0
  | 2025-05-29 12:00:39 UTC | [ERROR] Error: Unable to build website for locale en.
  | 2025-05-29 12:00:39 UTC | at tryToBuildLocale (/usr/src/app/docusaurus/node_modules/@docusaurus/core/lib/commands/build/build.js:78:15)
  | 2025-05-29 12:00:39 UTC | at async /usr/src/app/docusaurus/node_modules/@docusaurus/core/lib/commands/build/build.js:34:9
  | 2025-05-29 12:00:39 UTC | at async mapAsyncSequential (/usr/src/app/docusaurus/node_modules/@docusaurus/utils/lib/jsUtils.js:21:24)
  | 2025-05-29 12:00:39 UTC | at async Command.build (/usr/src/app/docusaurus/node_modules/@docusaurus/core/lib/commands/build/build.js:33:5)
  | 2025-05-29 12:00:39 UTC | at async Promise.all (index 0)
  | 2025-05-29 12:00:39 UTC | at async runCLI (/usr/src/app/docusaurus/node_modules/@docusaurus/core/lib/commands/cli.js:56:5)
  | 2025-05-29 12:00:39 UTC | at async file:///usr/src/app/docusaurus/node_modules/@docusaurus/core/bin/docusaurus.mjs:44:3 {
  | 2025-05-29 12:00:39 UTC | [cause]: ReferenceError: self is not defined
  | 2025-05-29 12:00:39 UTC | at 48036 (server.bundle.js:388977:63)
  | 2025-05-29 12:00:39 UTC | at __webpack_require__ (server.bundle.js:831439:42)
  | 2025-05-29 12:00:39 UTC | at 67781 (server.bundle.js:563858:17)
  | 2025-05-29 12:00:39 UTC | at __webpack_require__ (server.bundle.js:831439:42)
  | 2025-05-29 12:00:39 UTC | at 4023 (server.bundle.js:27378:14)
  | 2025-05-29 12:00:39 UTC | at __webpack_require__ (server.bundle.js:831439:42)
  | 2025-05-29 12:00:39 UTC | at 94045 (server.bundle.js:780866:21)
  | 2025-05-29 12:00:39 UTC | at __webpack_require__ (server.bundle.js:831439:42)
  | 2025-05-29 12:00:39 UTC | at server.bundle.js:831572:37
  | 2025-05-29 12:00:39 UTC | at server.bundle.js:831575:12
  | 2025-05-29 12:00:39 UTC | }
  | 2025-05-29 12:00:39 UTC | exit status 1
```
I've traced it down to `@gleanwork/web-sdk` trying to do something unexpected during SSR. Dynamic loading solved the problem.

The PR also makes type imports explicit by adding `type` and changes the deprecated `JSX.Element` to `ReactNode`