### PR TITLE
fix search context

### DIFF
--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -11,7 +11,6 @@ function SearchBarInner() {
   const containerRef = useRef<HTMLSpanElement>(null);
   const { options } = useGleanConfig();
   const { initializeSDK, cleanup } = useGleanSDK();
-  const backend = (options.searchOptions as ModalSearchOptions)?.backend;
 
   const searchOptions = useMemo(
     () => options.searchOptions as ModalSearchOptions,
@@ -26,7 +25,7 @@ function SearchBarInner() {
 
       await initializeSDK(themeVariant, searchOptions, (sdk, finalOptions) => {
         if (containerRef.current) {
-          sdk.attach(containerRef.current, finalOptions);
+          sdk.default.attach(containerRef.current, finalOptions);
         }
       });
     },
@@ -60,21 +59,26 @@ function SearchBarInner() {
     return cleanup;
   }, [initializeSearch, initialTheme, cleanup]);
 
-  const searchElement = (
+  return (
     <span ref={containerRef}>
       <SearchButton />
     </span>
   );
+}
+
+function SearchBarWrapper() {
+  const { options } = useGleanConfig();
+  const backend = (options.searchOptions as ModalSearchOptions)?.backend;
 
   if (options.enableAnonymousAuth && backend) {
     return (
       <GuestAuthProvider pluginOptions={options} backend={backend}>
-        {searchElement}
+        <SearchBarInner />
       </GuestAuthProvider>
     );
   }
 
-  return searchElement;
+  return <SearchBarInner />;
 }
 
 export default function SearchBar() {
@@ -84,5 +88,5 @@ export default function SearchBar() {
     </span>
   );
 
-  return <BrowserOnly fallback={fallback}>{() => <SearchBarInner />}</BrowserOnly>;
+  return <BrowserOnly fallback={fallback}>{() => <SearchBarWrapper />}</BrowserOnly>;
 }


### PR DESCRIPTION
Quick fix on the Glean guest auth: The GuestAuthProvider context was placed inside the same component trying to consume it, moved it to a parent wrapper so the auth context is available when needed.