### PR TITLE
chore: Adds yarn prepare to build on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "copy:watch": "node ./scripts/copyUntypedFiles.js --watch",
     "format": "prettier --write .",
     "lint": "prettier --check . && eslint --cache --report-unused-disable-directives ./src",
+    "prepare": "yarn build",
     "release": "rm -rf lib && yarn build && release-it",
     "test": "vitest run",
     "test:all": "yarn lint && yarn test",


### PR DESCRIPTION
This pull request adds a new script to the `package.json` file to ensure the project is built during the `prepare` lifecycle step. This change helps automate the build process when preparing the package for publishing or installation.