### PR TITLE
chore: Updates @gleanwork/web-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "watch": "run-p -c copy:watch build:watch"
   },
   "dependencies": {
-    "@gleanwork/web-sdk": "^2.2.0-next.0",
+    "@gleanwork/web-sdk": "^2.3.0-next.0",
     "lodash.mergewith": "^4.6.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2320,10 +2320,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gleanwork/web-sdk@npm:^2.2.0-next.0":
-  version: 2.2.0-next.0
-  resolution: "@gleanwork/web-sdk@npm:2.2.0-next.0"
-  checksum: d7d9598819dd6d56ce2a07fdb8a13b52a3ce1863de8729020cc472425a4fa8b39ff9f7a6117d6b61010755c24563c28f1f74eb61a7401490d6c1bfadd944d4b7
+"@gleanwork/web-sdk@npm:^2.3.0-next.0":
+  version: 2.3.0-next.0
+  resolution: "@gleanwork/web-sdk@npm:2.3.0-next.0"
+  checksum: e7b3533ca51e46e74546d601be3b74eb674cc95eac23fec0769651ec60a9d463da2d7296011f33939037179c2d01ca00709b3643797e06d6a2c32a5a2db963bc
   languageName: node
   linkType: hard
 
@@ -6062,7 +6062,7 @@ __metadata:
     "@docusaurus/types": 3.8.1
     "@docusaurus/utils": 3.8.1
     "@docusaurus/utils-validation": 3.8.1
-    "@gleanwork/web-sdk": ^2.2.0-next.0
+    "@gleanwork/web-sdk": ^2.3.0-next.0
     "@release-it-plugins/lerna-changelog": 7.0.0
     "@types/lodash": 4.17.20
     "@types/node": 20.19.4


### PR DESCRIPTION
This pull request updates the `package.json` file to upgrade the `@gleanwork/web-sdk` dependency to version `^2.2.0-next.0`.