### PR TITLE
fix: remove broken client export

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,6 @@
     "*.css"
   ],
   "exports": {
-    "./client": {
-      "types": "./lib/client/index.d.ts",
-      "default": "./lib/client/index.js"
-    },
     ".": {
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"


### PR DESCRIPTION
## Summary
- remove the `./client` package export because it points to files that are not published
- keep the root package export unchanged

## Why
`docusaurus-plugin-search-glean@0.7.0` currently advertises:

```json
"./client": {
  "types": "./lib/client/index.d.ts",
  "default": "./lib/client/index.js"
}
```

The published npm tarball does not include `lib/client/index.js` or `lib/client/index.d.ts`, and this repository does not currently have a `src/client` entrypoint to build those files from. Removing the stale subpath export keeps the package export map aligned with the files that actually ship.

## Validation
- `npm view docusaurus-plugin-search-glean@0.7.0 name version main types exports files repository homepage bugs --json`
- `npm pack docusaurus-plugin-search-glean@0.7.0 --dry-run --ignore-scripts --json`
- `npm install --ignore-scripts --no-audit --no-fund --package-lock=false`
- `npm run build`
- `npm test` (15 tests passed)
- `npm run lint`
- package export target existence assertion
- `npm pack --dry-run --json .` using a temporary validation shim for the existing `prepare` hook so it runs the already-passing `npm run build`
- `git diff --check`
